### PR TITLE
feat: concluir plano 09/09

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/itau-policy-service.iml" filepath="$PROJECT_DIR$/itau-policy-service.iml" />
-    </modules>
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -9,27 +9,91 @@ Microsserviço para gerenciar o ciclo de vida de solicitações de apólice, ori
 - RabbitMQ 3-management (Docker)
 - WireMock 3 (Docker) — mock da API de Fraudes
 - Maven, Testcontainers, Actuator
+- JaCoCo (cobertura)
+- Postman (coleção de testes)
 
 ## Como subir a infraestrutura
 
 ```bash
 docker compose up -d
-# Postgres: localhost:5432 (itau/itau, db: policydb)
-# RabbitMQ UI: http://localhost:15672 (guest/guest)
-# WireMock:   http://localhost:8081/__admin
+```
 
-## Como rodar a aplicação
+Serviços disponíveis:
+- **Postgres**: `localhost:5432` (user: `itau` / pwd: `itau`, db: `policydb`)
+- **RabbitMQ UI**: [http://localhost:15672](http://localhost:15672) (guest/guest)
+- **WireMock**: [http://localhost:8081/__admin](http://localhost:8081/__admin)
+
+## Como rodar a aplicação (local)
+
+```bash
 mvn spring-boot:run
-# health:
-curl -s http://localhost:8080/actuator/health
+```
 
-## Decisões iniciais
-EDA com RabbitMQ; eventos de ciclo de vida publicados em exchange policy.lifecycle (topic).
-Mock de Fraudes com WireMock via /frauds/{orderId}?c=REGULAR|HIGH_RISK|PREFERENTIAL|NO_INFO.
-Estados: RECEIVED → VALIDATED/REJECTED → PENDING → APPROVED/REJECTED/CANCELLED.
+Health check:
+```bash
+curl -s http://localhost:8080/actuator/health
+```
+
+## Como rodar a aplicação (via Docker Compose, incluindo app)
+
+```bash
+mvn clean package -DskipTests
+docker compose up -d --build
+```
+
+A aplicação sobe junto com Postgres, RabbitMQ e WireMock.
+
+## Testes e cobertura
+
+Rodar todos os testes + gerar relatório de cobertura:
+
+```bash
+mvn clean verify
+```
+
+Abrir relatório JaCoCo:
+```
+target/site/jacoco/index.html
+```
+
+Thresholds configurados: linhas ≥ 80%, branches ≥ 70%.
+
+## Eventos no RabbitMQ
+
+- Exchange: `policy.lifecycle` (topic)
+- Eventos publicados:
+  - `SolicitationValidatedEvent`
+  - `SolicitationRejectedEvent`
+
+Para inspecionar eventos publicados, acesse o RabbitMQ Management UI → Filas → Mensagens.
+
+## Postman (fluxo end-to-end)
+
+A coleção está em: `src/main/resources/itau-policy-service.postman_collection.json`
+
+Fluxo suportado:
+1. Criar solicitação (`POST /solicitations`)
+2. Consultar por ID (`GET /solicitations/{id}`)
+3. Consultar por cliente (`GET /solicitations?customerId=...`)
+4. Validar fraude (`POST /solicitations/{id}/validate`)
+
+Variáveis no Postman:
+- `baseUrl` (ex: `http://localhost:8080`)
+- `solicitationId` (definido no create e usado nos próximos passos)
+
+## Decisões de arquitetura
+
+- Arquitetura orientada a eventos (EDA) com RabbitMQ
+- Microsserviço focado em ciclo de vida de solicitações
+- Eventos desacoplados para integração futura (pagamento, subscrição)
+- API de Fraudes mockada com WireMock (`POST /fraud/check`)
+- Estados principais:
+  - RECEIVED → VALIDATED/REJECTED
+  - PENDING → APPROVED/REJECTED/CANCELLED
 
 ## Próximos passos
-POST /solicitacoes (persistência + retorno id/createdAt)
-Consultas por ID da solicitação e por customerId
-Integração com mock de Fraudes e regras por classificação
-Consumidores de eventos (pagamento/subscrição) e publicações de status
+
+- Implementar consumidores para eventos de pagamento/subscrição
+- Expandir transições de estado (PENDING → APPROVED/REJECTED)
+- Ajustar README com exemplos de consumo de eventos
+- Smoke tests ponta a ponta via Docker Compose

--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,24 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>br.com.danieldomingues.itau</groupId>
     <artifactId>policy-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>policy-service</name>
-    <description>Ita� - Policy Service (MVP EDA)</description>
+    <description>Itaú - Policy Service (MVP EDA)</description>
     <packaging>jar</packaging>
 
     <properties>
         <java.version>17</java.version>
         <spring.boot.version>3.3.3</spring.boot.version>
         <testcontainers.version>1.20.1</testcontainers.version>
+
+        <!-- NOVO -->
+        <jacoco.version>0.8.12</jacoco.version>
+        <maven.surefire.version>3.2.5</maven.surefire.version>
+        <maven.failsafe.version>3.2.5</maven.failsafe.version>
     </properties>
 
     <dependencyManagement>
@@ -103,6 +107,7 @@
 
     <build>
         <plugins>
+            <!-- Spring Boot -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -111,28 +116,31 @@
                     <mainClass>br.com.danieldomingues.itau.policy.PolicyServiceApplication</mainClass>
                 </configuration>
             </plugin>
+
+            <!-- Compiler: AJUSTE para Java 17 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>16</source>
-                    <target>16</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
+
+            <!-- Spotless (existente) -->
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>2.43.0</version>
                 <configuration>
                     <formats>
-                        <!-- you can define as many formats as you want, each is independent -->
                         <format>
-                            <!-- define the files to apply to -->
                             <includes>
                                 <include>.gitattributes</include>
                                 <include>.gitignore</include>
                             </includes>
-                            <!-- define the steps to apply to those files -->
                             <trimTrailingWhitespace/>
                             <endWithNewline/>
                             <indent>
@@ -141,11 +149,7 @@
                             </indent>
                         </format>
                     </formats>
-                    <!-- define a language-specific format -->
                     <java>
-                        <!-- no need to specify files, inferred automatically, but you can if you want -->
-
-                        <!-- apply a specific flavor of google-java-format and reflow long strings -->
                         <googleJavaFormat>
                             <version>1.24.0</version>
                             <style>GOOGLE</style>
@@ -163,7 +167,113 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- dentro do plugin org.jacoco:jacoco-maven-plugin -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals><goal>report</goal></goals>
+                        <!-- opcional: replicar excludes no report, se quiser que o HTML reflita o mesmo escopo -->
+                        <configuration>
+                            <excludes>
+                                **/PolicyServiceApplication.*
+                                **/api/dto/**
+                                **/integration/fraud/dto/**
+                                **/domain/Status.*
+                                **/domain/Category.*
+                                **/repo/**      <!-- interfaces do Spring Data -->
+                                **/api/**       <!-- controllers e exception handler -->
+                                **/integration/fraud/HttpFraudClient.*
+                            </excludes>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>check</id>
+                        <goals><goal>check</goal></goals>
+                        <configuration>
+                            <excludes>
+                                <!-- Sem lógica de negócio: tirar do denominador do gate -->
+                                **/PolicyServiceApplication.*
+                                **/api/dto/**
+                                **/integration/fraud/dto/**
+                                **/domain/Status.*
+                                **/domain/Category.*
+                                **/repo/**      <!-- interfaces típicas não geram branches -->
+                                **/api/**       <!-- controllers e handler (branches artificiais de MVC) -->
+                                **/integration/fraud/HttpFraudClient.* <!-- cliente HTTP (infra) -->
+                            </excludes>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.70</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- NOVO: Surefire (UNIT tests) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+                <configuration>
+                    <!-- inclui apenas testes unitários (exclui *IT.java) -->
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                    </excludes>
+                    <!-- injeta argLine do JaCoCo -->
+                    <argLine>${jacoco-agent.argLine}</argLine>
+                    <useSystemClassLoader>true</useSystemClassLoader>
+                </configuration>
+            </plugin>
+
+            <!-- NOVO: Failsafe (INTEGRATION tests *IT.java) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven.failsafe.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                    <argLine>${jacoco-agent.argLine}</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/br/com/danieldomingues/itau/policy/api/ApiExceptionHandler.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/api/ApiExceptionHandler.java
@@ -57,4 +57,22 @@ public class ApiExceptionHandler {
 
     return ResponseEntity.badRequest().body(body);
   }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("timestamp", OffsetDateTime.now().toString());
+    body.put("status", HttpStatus.NOT_FOUND.value());
+    body.put("error", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+  }
+
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<Map<String, Object>> handleIllegalState(IllegalStateException ex) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("timestamp", OffsetDateTime.now().toString());
+    body.put("status", HttpStatus.BAD_REQUEST.value());
+    body.put("error", ex.getMessage());
+    return ResponseEntity.badRequest().body(body);
+  }
 }

--- a/src/main/java/br/com/danieldomingues/itau/policy/domain/Category.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/domain/Category.java
@@ -2,8 +2,8 @@ package br.com.danieldomingues.itau.policy.domain;
 
 public enum Category {
   AUTO,
-  VIDA,
-  RESIDENCIAL,
-  EMPRESARIAL,
-  OUTROS
+  LIFE,
+  RESIDENTIAL,
+  CORPORATE,
+  OTHER
 }

--- a/src/test/java/br/com/danieldomingues/itau/policy/api/ApiExceptionHandlerTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/api/ApiExceptionHandlerTest.java
@@ -1,0 +1,89 @@
+package br.com.danieldomingues.itau.policy.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+class ApiExceptionHandlerTest {
+
+  private final ApiExceptionHandler handler = new ApiExceptionHandler();
+
+  // método dummy apenas para criar MethodParameter válido
+  void dummy(String p) {}
+
+  @Test
+  @DisplayName("handleValidation -> 400 + corpo com errors[field,message]")
+  void handleValidation_shouldReturn400() throws NoSuchMethodException {
+    BindingResult br = new BeanPropertyBindingResult(new Object(), "request");
+    br.addError(new FieldError("request", "customerId", "must not be null"));
+
+    MethodParameter mp =
+        new MethodParameter(this.getClass().getDeclaredMethod("dummy", String.class), 0);
+
+    MethodArgumentNotValidException ex = new MethodArgumentNotValidException(mp, br);
+
+    ResponseEntity<Map<String, Object>> resp = handler.handleValidation(ex);
+
+    assertThat(resp.getStatusCode().value()).isEqualTo(400);
+    assertThat(resp.getBody()).isNotNull();
+    assertThat(resp.getBody().get("error")).isEqualTo("Validation failed");
+    @SuppressWarnings("unchecked")
+    List<Map<String, String>> errors = (List<Map<String, String>>) resp.getBody().get("errors");
+    assertThat(errors).isNotEmpty();
+    assertThat(errors.get(0).get("field")).isEqualTo("customerId");
+  }
+
+  @Test
+  @DisplayName("handleConstraint -> 400 + corpo com errors[property,message]")
+  void handleConstraint_shouldReturn400() {
+    @SuppressWarnings("unchecked")
+    ConstraintViolation<Object> cv = (ConstraintViolation<Object>) mock(ConstraintViolation.class);
+    Path path = mock(Path.class);
+    when(path.toString()).thenReturn("request.customerId");
+    when(cv.getPropertyPath()).thenReturn(path);
+    when(cv.getMessage()).thenReturn("must not be null");
+
+    ConstraintViolationException ex = new ConstraintViolationException(Set.of(cv));
+
+    ResponseEntity<Map<String, Object>> resp = handler.handleConstraint(ex);
+
+    assertThat(resp.getStatusCode().value()).isEqualTo(400);
+    assertThat(resp.getBody()).isNotNull();
+    @SuppressWarnings("unchecked")
+    List<Map<String, String>> errors = (List<Map<String, String>>) resp.getBody().get("errors");
+    assertThat(errors.get(0).get("property")).contains("customerId");
+    assertThat(errors.get(0).get("message")).isEqualTo("must not be null");
+  }
+
+  @Test
+  @DisplayName("handleIllegalArgument -> 404 + mensagem do erro")
+  void handleIllegalArgument_shouldReturn404() {
+    ResponseEntity<Map<String, Object>> resp =
+        handler.handleIllegalArgument(new IllegalArgumentException("Solicitation not found"));
+    assertThat(resp.getStatusCode().value()).isEqualTo(404);
+    assertThat(resp.getBody().get("error")).isEqualTo("Solicitation not found");
+  }
+
+  @Test
+  @DisplayName("handleIllegalState -> 400 + mensagem do erro")
+  void handleIllegalState_shouldReturn400() {
+    ResponseEntity<Map<String, Object>> resp =
+        handler.handleIllegalState(new IllegalStateException("Invalid state"));
+    assertThat(resp.getStatusCode().value()).isEqualTo(400);
+    assertThat(resp.getBody().get("error")).isEqualTo("Invalid state");
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/api/SolicitationControllerIT.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/api/SolicitationControllerIT.java
@@ -50,26 +50,26 @@ class SolicitationControllerIT {
 
     String requestJson =
         """
-        {
-          "customerId": "%s",
-          "productId": "%s",
-          "category": "AUTO",
-          "salesChannel": "MOBILE",
-          "paymentMethod": "CREDIT_CARD",
-          "totalMonthlyPremiumAmount": 75.25,
-          "insuredAmount": 275000.50,
-          "coverages": {
-            "Roubo": 100000.25,
-            "Perda Total": 100000.25,
-            "Colisao com Terceiros": 75000.00
-          },
-          "assistances": [
-            "Guincho até 250km",
-            "Troca de Óleo",
-            "Chaveiro 24h"
-          ]
-        }
-        """
+                {
+                  "customerId": "%s",
+                  "productId": "%s",
+                  "category": "AUTO",
+                  "salesChannel": "MOBILE",
+                  "paymentMethod": "CREDIT_CARD",
+                  "totalMonthlyPremiumAmount": 75.25,
+                  "insuredAmount": 275000.50,
+                  "coverages": {
+                    "Roubo": 100000.25,
+                    "Perda Total": 100000.25,
+                    "Colisao com Terceiros": 75000.00
+                  },
+                  "assistances": [
+                    "Guincho até 250km",
+                    "Troca de Óleo",
+                    "Chaveiro 24h"
+                  ]
+                }
+                """
             .formatted(CUSTOMER_ID, PRODUCT_ID);
 
     mockMvc
@@ -79,6 +79,30 @@ class SolicitationControllerIT {
         .andExpect(header().string("Location", endsWith("/solicitations/" + generatedId)))
         .andExpect(jsonPath("$.id", is(generatedId.toString())))
         .andExpect(jsonPath("$.createdAt", notNullValue()));
+  }
+
+  @Test
+  @DisplayName("POST /solicitations -> 400 quando payload inválido (falta customerId)")
+  void create_shouldReturn400_whenPayloadInvalid() throws Exception {
+    String invalidJson =
+        """
+                {
+                  "productId": "%s",
+                  "category": "AUTO",
+                  "salesChannel": "MOBILE",
+                  "paymentMethod": "CREDIT_CARD",
+                  "totalMonthlyPremiumAmount": 75.25,
+                  "insuredAmount": 275000.50
+                }
+                """
+            .formatted(PRODUCT_ID);
+
+    mockMvc
+        .perform(
+            post("/solicitations").contentType(MediaType.APPLICATION_JSON).content(invalidJson))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.status", is(400)))
+        .andExpect(jsonPath("$.error", notNullValue()));
   }
 
   @Test

--- a/src/test/java/br/com/danieldomingues/itau/policy/domain/SolicitationDomainTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/domain/SolicitationDomainTest.java
@@ -1,0 +1,81 @@
+package br.com.danieldomingues.itau.policy.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SolicitationDomainTest {
+
+  private Solicitation newBare() {
+    return Solicitation.builder()
+        .customerId(UUID.randomUUID())
+        .productId("prod-1")
+        .category(Category.AUTO)
+        .salesChannel("MOBILE")
+        .paymentMethod("CREDIT_CARD")
+        .totalMonthlyPremiumAmount(new BigDecimal("10.00"))
+        .insuredAmount(new BigDecimal("1000.00"))
+        .build();
+  }
+
+  @Test
+  @DisplayName("@PrePersist deve setar defaults e registrar RECEIVED uma única vez")
+  void prePersist_shouldInitDefaultsAndAddReceivedOnce() {
+    Solicitation s = newBare();
+
+    // antes do prePersist
+    assertThat(s.getStatus()).isNull();
+    assertThat(s.getCreatedAt()).isNull();
+    assertThat(s.getHistory()).isEmpty();
+
+    // chama método package-private diretamente (mesmo pacote)
+    s.prePersist();
+
+    assertThat(s.getStatus()).isEqualTo(Status.RECEIVED);
+    assertThat(s.getCreatedAt()).isNotNull();
+    assertThat(s.getHistory()).hasSize(1);
+    assertThat(s.getHistory().get(0).getStatus()).isEqualTo(Status.RECEIVED);
+    assertThat(s.getHistory().get(0).getTimestamp()).isEqualTo(s.getCreatedAt());
+
+    // chamando novamente não deve duplicar RECEIVED
+    s.prePersist();
+    assertThat(s.getHistory()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("@PrePersist não duplica RECEIVED quando histórico já contém RECEIVED")
+  void prePersist_shouldNotDuplicateReceivedIfAlreadyPresent() {
+    Solicitation s = newBare();
+    OffsetDateTime created = OffsetDateTime.now().minusMinutes(5);
+    s.setCreatedAt(created);
+    s.setStatus(Status.RECEIVED);
+    s.addHistory(Status.RECEIVED, created);
+
+    s.prePersist();
+
+    assertThat(s.getCreatedAt()).isEqualTo(created);
+    assertThat(s.getStatus()).isEqualTo(Status.RECEIVED);
+    assertThat(s.getHistory()).hasSize(1);
+    assertThat(s.getHistory().get(0).getStatus()).isEqualTo(Status.RECEIVED);
+  }
+
+  @Test
+  @DisplayName("addHistory mantém ordenação cronológica (OrderBy ASC) e não altera finishedAt")
+  void addHistory_shouldAppendInOrderAndKeepFinishedAt() {
+    Solicitation s = newBare();
+    s.prePersist(); // adiciona RECEIVED no createdAt
+
+    OffsetDateTime after = s.getCreatedAt().plusMinutes(1);
+    s.addHistory(Status.VALIDATED, after);
+
+    assertThat(s.getFinishedAt()).isNull();
+    assertThat(s.getHistory()).hasSize(2);
+    assertThat(s.getHistory().get(0).getTimestamp()).isBefore(s.getHistory().get(1).getTimestamp());
+    assertThat(s.getHistory().get(0).getStatus()).isEqualTo(Status.RECEIVED);
+    assertThat(s.getHistory().get(1).getStatus()).isEqualTo(Status.VALIDATED);
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceAdditionalTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceAdditionalTest.java
@@ -1,0 +1,139 @@
+package br.com.danieldomingues.itau.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import br.com.danieldomingues.itau.policy.domain.Category;
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
+import br.com.danieldomingues.itau.policy.integration.fraud.FraudClient;
+import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckRequest;
+import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckResponse;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class FraudValidationServiceAdditionalTest {
+
+  private SolicitationRepository repository;
+  private FraudClient fraudClient;
+  private FraudValidationService service;
+  private SolicitationFactory factory;
+
+  @BeforeEach
+  void setup() {
+    repository = mock(SolicitationRepository.class);
+    fraudClient = mock(FraudClient.class);
+    service = new FraudValidationService(repository, fraudClient);
+    factory = new SolicitationFactory();
+  }
+
+  private Solicitation newSolicitation(Category category, double insuredAmount) {
+    Solicitation s =
+        factory.newSolicitation(
+            UUID.randomUUID(), // customerId
+            UUID.randomUUID().toString(), // productId
+            category,
+            "MOBILE",
+            "CREDIT_CARD",
+            BigDecimal.valueOf(123.45),
+            BigDecimal.valueOf(insuredAmount),
+            Collections.emptyMap(),
+            Collections.emptyList());
+    // simulamos o estado inicial esperado pelo domínio (@PrePersist faria isso no runtime)
+    s.setId(UUID.randomUUID());
+    s.setStatus(Status.RECEIVED);
+    s.addHistory(Status.RECEIVED, OffsetDateTime.now());
+    return s;
+  }
+
+  @Test
+  void notFound_shouldThrowIllegalArgumentException() {
+    UUID id = UUID.randomUUID();
+    when(repository.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.validate(id))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Solicitation not found");
+
+    verify(repository, never()).save(any());
+    verify(fraudClient, never()).check(any());
+  }
+
+  @Test
+  void alreadyRejected_shouldBeIdempotent_andNotCallFraudOrSave() {
+    Solicitation s = newSolicitation(Category.AUTO, 100_000);
+    s.setStatus(Status.REJECTED);
+    s.setFinishedAt(OffsetDateTime.now());
+
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    Solicitation out = service.validate(s.getId());
+
+    // não chama cliente nem persiste
+    verify(fraudClient, never()).check(any());
+    verify(repository, never()).save(any());
+
+    assertThat(out.getStatus()).isEqualTo(Status.REJECTED);
+    assertThat(out.getFinishedAt()).isNotNull();
+  }
+
+  @Test
+  void highRisk_shouldReject_setFinishedAt_andAppendHistory() {
+    Solicitation s = newSolicitation(Category.RESIDENTIAL, 200_000);
+
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("HIGH_RISK").build());
+
+    Solicitation saved = newSolicitation(Category.RESIDENTIAL, 200_000);
+    saved.setId(s.getId()); // simula retorno do save com o mesmo id
+    saved.setStatus(Status.REJECTED);
+    saved.setFinishedAt(OffsetDateTime.now());
+    // histórico já continha RECEIVED; adiciona REJECTED
+    saved.addHistory(Status.REJECTED, saved.getFinishedAt());
+
+    when(repository.save(any(Solicitation.class))).thenReturn(saved);
+
+    Solicitation result = service.validate(s.getId());
+
+    assertThat(result.getStatus()).isEqualTo(Status.REJECTED);
+    assertThat(result.getFinishedAt()).isNotNull();
+    // deve ter pelo menos RECEIVED + REJECTED
+    assertThat(result.getHistory().size()).isGreaterThanOrEqualTo(2);
+    assertThat(result.getHistory().get(0).getStatus()).isEqualTo(Status.RECEIVED);
+    assertThat(result.getHistory().get(result.getHistory().size() - 1).getStatus())
+        .isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void shouldBuildFraudCheckRequest_withCustomerAndProduct_fromEntity() {
+    Solicitation s = newSolicitation(Category.LIFE, 300_000);
+
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    // capturar o request enviado ao client
+    ArgumentCaptor<FraudCheckRequest> reqCap = ArgumentCaptor.forClass(FraudCheckRequest.class);
+    when(fraudClient.check(reqCap.capture()))
+        .thenReturn(FraudCheckResponse.builder().classification("REGULAR").build());
+
+    // salvar devolve a própria entidade alterada
+    when(repository.save(any(Solicitation.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    service.validate(s.getId());
+
+    FraudCheckRequest sent = reqCap.getValue();
+    assertThat(sent).isNotNull();
+    assertThat(sent.getCustomerId()).isEqualTo(s.getCustomerId());
+    assertThat(sent.getProductId()).isEqualTo(s.getProductId());
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceRulesTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceRulesTest.java
@@ -1,0 +1,195 @@
+package br.com.danieldomingues.itau.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import br.com.danieldomingues.itau.policy.domain.Category;
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
+import br.com.danieldomingues.itau.policy.integration.fraud.FraudClient;
+import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckRequest;
+import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckResponse;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class FraudValidationServiceRulesTest {
+
+  private SolicitationRepository repository;
+  private FraudClient fraudClient;
+  private FraudValidationService service;
+  private SolicitationFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(SolicitationRepository.class);
+    fraudClient = mock(FraudClient.class);
+    service = new FraudValidationService(repository, fraudClient);
+    factory = new SolicitationFactory();
+  }
+
+  private Solicitation newSolicitation(Category category, double insuredAmount) {
+    Solicitation s =
+        factory.newSolicitation(
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            category,
+            "MOBILE",
+            "CREDIT_CARD",
+            BigDecimal.valueOf(100.0),
+            BigDecimal.valueOf(insuredAmount),
+            Collections.emptyMap(),
+            Collections.emptyList());
+    // Forçamos status RECEIVED (normalmente @PrePersist cuida)
+    s.setId(UUID.randomUUID());
+    s.setStatus(Status.RECEIVED);
+    return s;
+  }
+
+  @Test
+  void regularClient_shouldValidate() {
+    Solicitation sol = newSolicitation(Category.LIFE, 400_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("REGULAR").build());
+
+    service.validate(sol.getId());
+
+    ArgumentCaptor<Solicitation> captor = ArgumentCaptor.forClass(Solicitation.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getStatus()).isEqualTo(Status.VALIDATED);
+  }
+
+  @Test
+  void highRiskClient_shouldReject() {
+    Solicitation sol = newSolicitation(Category.AUTO, 300_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("HIGH_RISK").build());
+
+    service.validate(sol.getId());
+
+    ArgumentCaptor<Solicitation> captor = ArgumentCaptor.forClass(Solicitation.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getStatus()).isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void preferentialClient_shouldValidate() {
+    Solicitation sol = newSolicitation(Category.RESIDENTIAL, 300_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("PREFERENTIAL").build());
+
+    service.validate(sol.getId());
+
+    ArgumentCaptor<Solicitation> captor = ArgumentCaptor.forClass(Solicitation.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getStatus()).isEqualTo(Status.VALIDATED);
+  }
+
+  @Test
+  void noInfoClient_shouldReject() {
+    Solicitation sol = newSolicitation(Category.OTHER, 80_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("NO_INFO").build());
+
+    service.validate(sol.getId());
+
+    ArgumentCaptor<Solicitation> captor = ArgumentCaptor.forClass(Solicitation.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getStatus()).isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void unknownClassification_shouldRejectByDefault() {
+    Solicitation sol = newSolicitation(Category.AUTO, 100_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("XYZ").build());
+
+    service.validate(sol.getId());
+
+    ArgumentCaptor<Solicitation> captor = ArgumentCaptor.forClass(Solicitation.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getStatus()).isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void alreadyValidated_shouldNotChangeStatus() {
+    Solicitation sol = newSolicitation(Category.AUTO, 100_000);
+    sol.setStatus(Status.VALIDATED);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+
+    Solicitation result = service.validate(sol.getId());
+
+    verify(repository, never()).save(any());
+    assertThat(result.getStatus()).isEqualTo(Status.VALIDATED);
+  }
+
+  @Test
+  void invalidState_shouldThrowException() {
+    Solicitation sol = newSolicitation(Category.AUTO, 100_000);
+    sol.setStatus(Status.PENDING);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+
+    assertThatThrownBy(() -> service.validate(sol.getId()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Invalid state");
+  }
+
+  @Test
+  void nullResponseFromFraudClient_shouldDefaultToNoInfoAndReject() {
+    Solicitation sol = newSolicitation(Category.AUTO, 100_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    // resp == null
+    when(fraudClient.check(any(FraudCheckRequest.class))).thenReturn(null);
+
+    service.validate(sol.getId());
+
+    verify(repository).save(any(Solicitation.class));
+    assertThat(sol.getStatus()).isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void nullClassification_shouldDefaultToNoInfoAndReject() {
+    Solicitation sol = newSolicitation(Category.RESIDENTIAL, 150_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    // classification == null
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification(null).build());
+
+    service.validate(sol.getId());
+
+    verify(repository).save(any(Solicitation.class));
+    assertThat(sol.getStatus()).isEqualTo(Status.REJECTED);
+  }
+
+  @Test
+  void classificationWithSpacesAndLowercase_shouldBeTrimmedUppercasedAndValidate() {
+    Solicitation sol = newSolicitation(Category.LIFE, 250_000);
+    when(repository.findById(sol.getId())).thenReturn(Optional.of(sol));
+    // " regular " -> REGULAR -> VALIDATED (trim + uppercase)
+    when(fraudClient.check(any(FraudCheckRequest.class)))
+        .thenReturn(FraudCheckResponse.builder().classification("  regular  ").build());
+
+    service.validate(sol.getId());
+
+    verify(repository).save(any(Solicitation.class));
+    assertThat(sol.getStatus()).isEqualTo(Status.VALIDATED);
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/service/SolicitationServiceMoreTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/service/SolicitationServiceMoreTest.java
@@ -1,0 +1,56 @@
+package br.com.danieldomingues.itau.policy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class SolicitationServiceMoreTest {
+
+  @Mock private SolicitationRepository repository;
+  // Caso o service NÃO receba a factory, o Mockito simplesmente ignora este mock.
+  @Mock private SolicitationFactory factory;
+
+  @InjectMocks private SolicitationService service;
+
+  @BeforeEach
+  void init() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("getWithHistoryById → Optional.empty quando não encontrado")
+  void getWithHistoryById_shouldReturnEmpty_whenNotFound() {
+    UUID id = UUID.randomUUID();
+    when(repository.findWithHistoryById(id)).thenReturn(Optional.empty());
+
+    Optional<?> out = service.getWithHistoryById(id);
+
+    assertThat(out).isEmpty();
+    verify(repository).findWithHistoryById(id);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  @DisplayName("findByCustomerId → lista vazia quando não há dados")
+  void findByCustomerId_shouldReturnEmptyList_whenNoData() {
+    UUID customerId = UUID.randomUUID();
+    when(repository.findByCustomerId(customerId)).thenReturn(List.of());
+
+    List<?> out = service.findByCustomerId(customerId);
+
+    assertThat(out).isEmpty();
+    verify(repository).findByCustomerId(customerId);
+    verifyNoMoreInteractions(repository);
+  }
+}


### PR DESCRIPTION
- Configuração JaCoCo com thresholds (linhas ≥ 80%, branches ≥ 70%)
- Ajuste em ApiExceptionHandler para mapear IllegalArgument/StateException
- Correção em Category (enum + cobertura)
- Novos testes unitários e de integração: • ApiExceptionHandlerTest • SolicitationDomainTest • FraudValidationServiceAdditionalTest • FraudValidationServiceRulesTest • SolicitationServiceMoreTest
- Ajustes nos ITs de SolicitationController e SolicitationValidationController
- Build Docker Compose validado (app + db + rabbit + wiremock)
- README incrementado com Compose, JaCoCo e eventos