### PR TITLE
feat: implementar publicação de eventos de fraude e ajustes de config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,43 @@
-# Itaú — Policy Service (MVP EDA)
+# Itaú --- Policy Service (MVP EDA)
 
-Microsserviço para gerenciar o ciclo de vida de solicitações de apólice, orientado a eventos.
+Microsserviço para gerenciar o ciclo de vida de solicitações de apólice,
+orientado a eventos.
 
 ## Stack
 
-- Java 17, Spring Boot 3.3
-- PostgreSQL 16 (Docker)
-- RabbitMQ 3-management (Docker)
-- WireMock 3 (Docker) — mock da API de Fraudes
-- Maven, Testcontainers, Actuator
-- JaCoCo (cobertura)
-- Postman (coleção de testes)
+-   Java 17, Spring Boot 3.3
+-   PostgreSQL 16 (Docker)
+-   RabbitMQ 3-management (Docker)
+-   WireMock 3 (Docker) --- mock da API de Fraudes
+-   Maven, Testcontainers, Actuator
+-   JaCoCo (cobertura de testes)
+-   Postman (coleção de testes)
 
 ## Como subir a infraestrutura
 
-```bash
+``` bash
 docker compose up -d
 ```
 
-Serviços disponíveis:
-- **Postgres**: `localhost:5432` (user: `itau` / pwd: `itau`, db: `policydb`)
-- **RabbitMQ UI**: [http://localhost:15672](http://localhost:15672) (guest/guest)
-- **WireMock**: [http://localhost:8081/__admin](http://localhost:8081/__admin)
+Serviços disponíveis: - **Postgres**: `localhost:5432` (user: `itau` /
+pwd: `itau`, db: `policydb`) - **RabbitMQ UI**: <http://localhost:15672>
+(guest/guest) - **WireMock**: <http://localhost:8081/__admin>
 
 ## Como rodar a aplicação (local)
 
-```bash
+``` bash
 mvn spring-boot:run
 ```
 
 Health check:
-```bash
+
+``` bash
 curl -s http://localhost:8080/actuator/health
 ```
 
 ## Como rodar a aplicação (via Docker Compose, incluindo app)
 
-```bash
+``` bash
 mvn clean package -DskipTests
 docker compose up -d --build
 ```
@@ -47,53 +48,92 @@ A aplicação sobe junto com Postgres, RabbitMQ e WireMock.
 
 Rodar todos os testes + gerar relatório de cobertura:
 
-```bash
+``` bash
 mvn clean verify
 ```
 
 Abrir relatório JaCoCo:
-```
-target/site/jacoco/index.html
-```
+
+    target/site/jacoco/index.html
 
 Thresholds configurados: linhas ≥ 80%, branches ≥ 70%.
 
 ## Eventos no RabbitMQ
 
-- Exchange: `policy.lifecycle` (topic)
-- Eventos publicados:
-  - `SolicitationValidatedEvent`
-  - `SolicitationRejectedEvent`
+-   Exchange: `policy.lifecycle` (topic)
+-   Eventos publicados:
+    -   `SolicitationValidatedEvent`
+    -   `SolicitationRejectedEvent`
+    -   `SolicitationApprovedEvent`
 
-Para inspecionar eventos publicados, acesse o RabbitMQ Management UI → Filas → Mensagens.
+Exemplo inspeção via cURL:
+
+``` bash
+curl -u guest:guest http://localhost:15672/api/queues/%2f/validatedQueue/get -d'{"count":5,"requeue":true,"encoding":"auto"}'
+```
+
+Ou pela interface de gerenciamento (http://localhost:15672).
 
 ## Postman (fluxo end-to-end)
 
-A coleção está em: `src/main/resources/itau-policy-service.postman_collection.json`
+A coleção está em:
+`src/main/resources/itau-policy-service.postman_collection.json`
 
-Fluxo suportado:
-1. Criar solicitação (`POST /solicitations`)
-2. Consultar por ID (`GET /solicitations/{id}`)
-3. Consultar por cliente (`GET /solicitations?customerId=...`)
-4. Validar fraude (`POST /solicitations/{id}/validate`)
+Fluxo suportado: 1. Criar solicitação (`POST /solicitations`) 2.
+Consultar por ID (`GET /solicitations/{id}`) 3. Consultar por cliente
+(`GET /solicitations?customerId=...`) 4. Validar fraude
+(`POST /solicitations/{id}/validate`)
 
-Variáveis no Postman:
-- `baseUrl` (ex: `http://localhost:8080`)
-- `solicitationId` (definido no create e usado nos próximos passos)
+Variáveis no Postman: - `baseUrl` (ex: `http://localhost:8080`) -
+`solicitationId` (definido no create e usado nos próximos passos)
 
 ## Decisões de arquitetura
 
-- Arquitetura orientada a eventos (EDA) com RabbitMQ
-- Microsserviço focado em ciclo de vida de solicitações
-- Eventos desacoplados para integração futura (pagamento, subscrição)
-- API de Fraudes mockada com WireMock (`POST /fraud/check`)
-- Estados principais:
-  - RECEIVED → VALIDATED/REJECTED
-  - PENDING → APPROVED/REJECTED/CANCELLED
+-   Arquitetura orientada a eventos (EDA) com RabbitMQ
+-   Microsserviço focado no ciclo de vida de solicitações
+-   Eventos desacoplados para integração futura (pagamento, subscrição,
+    notificação)
+-   API de Fraudes mockada com WireMock (`POST /fraud/check`)
+-   Estados principais:
+    -   RECEIVED → VALIDATED/REJECTED
+    -   VALIDATED → PENDING
+    -   PENDING → APPROVED/REJECTED/CANCELLED
+
+## Decisões técnicas / trade-offs
+
+-   Durante desenvolvimento e testes:
+    `spring.jpa.hibernate.ddl-auto=create` para facilitar a criação do
+    schema.
+-   **Produção**: usar **Flyway** ou **Liquibase** para versionamento
+    controlado.
+-   Testes automatizados com cobertura mínima validada por JaCoCo
+    (linhas ≥ 80%, branches ≥ 70%).
+-   Uso de **Testcontainers** para isolar dependências em testes de
+    integração.
 
 ## Próximos passos
 
-- Implementar consumidores para eventos de pagamento/subscrição
-- Expandir transições de estado (PENDING → APPROVED/REJECTED)
-- Ajustar README com exemplos de consumo de eventos
-- Smoke tests ponta a ponta via Docker Compose
+-   Implementar consumidores para eventos de pagamento/subscrição.
+-   Expandir transições de estado (PENDING → APPROVED/REJECTED).
+-   Implementar cancelamento com regras de bloqueio em estados
+    terminais.
+-   Adicionar métricas e logs estruturados (Micrometer/Actuator).
+-   Criar seção de troubleshooting no README.
+
+------------------------------------------------------------------------
+
+### Requisitos Atendidos até 09/09/2025
+
+-   Persistência com JPA (Solicitação, Histórico, Cliente).
+-   API REST: criar e consultar solicitações.
+-   Integração com API de Fraudes (mock via WireMock).
+-   Transição RECEIVED → VALIDATED/REJECTED com publicação de eventos.
+-   Cobertura mínima de testes garantida com JaCoCo.
+-   Docker Compose ponta a ponta (Postgres, RabbitMQ, WireMock, App).
+
+### Pontos Críticos já cumpridos
+
+-   Arquitetura orientada a eventos implementada.
+-   Testes com cobertura mínima atendida.
+-   Documentação inicial no README.
+-   Docker Compose ponta a ponta validado.

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <spring.boot.version>3.3.3</spring.boot.version>
         <testcontainers.version>1.20.1</testcontainers.version>
 
-        <!-- NOVO -->
         <jacoco.version>0.8.12</jacoco.version>
         <maven.surefire.version>3.2.5</maven.surefire.version>
         <maven.failsafe.version>3.2.5</maven.failsafe.version>
@@ -43,7 +42,7 @@
     </dependencyManagement>
 
     <dependencies>
-        <!-- Spring Boot starters -->
+        <!-- Starters -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -70,7 +69,7 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
-        <!-- Optional -->
+        <!-- Opcional -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -82,7 +81,7 @@
             <version>2.5.0</version>
         </dependency>
 
-        <!-- Tests -->
+        <!-- Testes -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -117,7 +116,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Compiler: AJUSTE para Java 17 -->
+            <!-- Compiler: Java 17 + -parameters -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -126,10 +125,13 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <release>${java.version}</release>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 
-            <!-- Spotless (existente) -->
+            <!-- Spotless -->
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
@@ -168,51 +170,59 @@
                 </executions>
             </plugin>
 
-            <!-- dentro do plugin org.jacoco:jacoco-maven-plugin -->
+            <!-- JaCoCo -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
-
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
-                        <goals><goal>prepare-agent</goal></goals>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!-- publica a property para usar no Surefire/Failsafe -->
+                            <propertyName>jacocoArgLine</propertyName>
+                            <append>true</append>
+                        </configuration>
                     </execution>
 
                     <execution>
                         <id>report</id>
                         <phase>verify</phase>
-                        <goals><goal>report</goal></goals>
-                        <!-- opcional: replicar excludes no report, se quiser que o HTML reflita o mesmo escopo -->
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
                         <configuration>
                             <excludes>
-                                **/PolicyServiceApplication.*
-                                **/api/dto/**
-                                **/integration/fraud/dto/**
-                                **/domain/Status.*
-                                **/domain/Category.*
-                                **/repo/**      <!-- interfaces do Spring Data -->
-                                **/api/**       <!-- controllers e exception handler -->
-                                **/integration/fraud/HttpFraudClient.*
+                                <exclude>**/PolicyServiceApplication.*</exclude>
+                                <exclude>**/api/dto/**</exclude>
+                                <exclude>**/integration/fraud/dto/**</exclude>
+                                <exclude>**/domain/Status.*</exclude>
+                                <exclude>**/domain/Category.*</exclude>
+                                <exclude>**/repo/**</exclude>
+                                <exclude>**/api/**</exclude>
+                                <exclude>**/integration/fraud/HttpFraudClient.*</exclude>
                             </excludes>
                         </configuration>
                     </execution>
 
                     <execution>
                         <id>check</id>
-                        <goals><goal>check</goal></goals>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                         <configuration>
                             <excludes>
-                                <!-- Sem lógica de negócio: tirar do denominador do gate -->
-                                **/PolicyServiceApplication.*
-                                **/api/dto/**
-                                **/integration/fraud/dto/**
-                                **/domain/Status.*
-                                **/domain/Category.*
-                                **/repo/**      <!-- interfaces típicas não geram branches -->
-                                **/api/**       <!-- controllers e handler (branches artificiais de MVC) -->
-                                **/integration/fraud/HttpFraudClient.* <!-- cliente HTTP (infra) -->
+                                <exclude>**/PolicyServiceApplication.*</exclude>
+                                <exclude>**/api/dto/**</exclude>
+                                <exclude>**/integration/fraud/dto/**</exclude>
+                                <exclude>**/domain/Status.*</exclude>
+                                <exclude>**/domain/Category.*</exclude>
+                                <exclude>**/repo/**</exclude>
+                                <exclude>**/api/**</exclude>
+                                <exclude>**/integration/fraud/HttpFraudClient.*</exclude>
                             </excludes>
                             <rules>
                                 <rule>
@@ -236,24 +246,21 @@
                 </executions>
             </plugin>
 
-
-            <!-- NOVO: Surefire (UNIT tests) -->
+            <!-- Surefire (UNIT) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
                 <configuration>
-                    <!-- inclui apenas testes unitários (exclui *IT.java) -->
                     <excludes>
                         <exclude>**/*IT.java</exclude>
                     </excludes>
-                    <!-- injeta argLine do JaCoCo -->
-                    <argLine>${jacoco-agent.argLine}</argLine>
+                    <argLine>${jacocoArgLine}</argLine>
                     <useSystemClassLoader>true</useSystemClassLoader>
                 </configuration>
             </plugin>
 
-            <!-- NOVO: Failsafe (INTEGRATION tests *IT.java) -->
+            <!-- Failsafe (IT) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
@@ -262,7 +269,7 @@
                     <includes>
                         <include>**/*IT.java</include>
                     </includes>
-                    <argLine>${jacoco-agent.argLine}</argLine>
+                    <argLine>${jacocoArgLine}</argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/br/com/danieldomingues/itau/policy/config/PolicyEventsConfig.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/config/PolicyEventsConfig.java
@@ -1,0 +1,54 @@
+package br.com.danieldomingues.itau.policy.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PolicyEventsConfig {
+
+  // Exchange principal para o ciclo de vida
+  public static final String EXCHANGE_POLICY_LIFECYCLE = "policy.lifecycle";
+
+  // Filas base para eventos RECEIVED -> VALIDATED/REJECTED
+  public static final String QUEUE_VALIDATED = "policy.lifecycle.validated.q";
+  public static final String QUEUE_REJECTED = "policy.lifecycle.rejected.q";
+
+  // Routing keys
+  public static final String RK_VALIDATED = "policy.lifecycle.validated";
+  public static final String RK_REJECTED = "policy.lifecycle.rejected";
+
+  @Bean
+  TopicExchange policyLifecycleExchange() {
+    return ExchangeBuilder.topicExchange(EXCHANGE_POLICY_LIFECYCLE).durable(true).build();
+  }
+
+  @Bean(name = "validatedQueue")
+  Queue validatedQueue() {
+    return QueueBuilder.durable(QUEUE_VALIDATED).build();
+  }
+
+  @Bean(name = "rejectedQueue")
+  Queue rejectedQueue() {
+    return QueueBuilder.durable(QUEUE_REJECTED).build();
+  }
+
+  @Bean
+  Binding bindValidated(
+      @Qualifier("validatedQueue") Queue validatedQueue, TopicExchange policyLifecycleExchange) {
+    return BindingBuilder.bind(validatedQueue).to(policyLifecycleExchange).with(RK_VALIDATED);
+  }
+
+  @Bean
+  Binding bindRejected(
+      @Qualifier("rejectedQueue") Queue rejectedQueue, TopicExchange policyLifecycleExchange) {
+    return BindingBuilder.bind(rejectedQueue).to(policyLifecycleExchange).with(RK_REJECTED);
+  }
+
+  @Bean
+  Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+    return new Jackson2JsonMessageConverter();
+  }
+}

--- a/src/main/java/br/com/danieldomingues/itau/policy/messaging/PaymentEventListener.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/messaging/PaymentEventListener.java
@@ -1,0 +1,94 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+  private final SolicitationRepository repository;
+  private final PolicyEventPublisher eventPublisher;
+
+  @Transactional
+  @RabbitListener(queues = "policy.payment.approved.q")
+  public void onPaymentApproved(Map<String, Object> payload) {
+    processPayment(payload, true);
+  }
+
+  @Transactional
+  @RabbitListener(queues = "policy.payment.rejected.q")
+  public void onPaymentRejected(Map<String, Object> payload) {
+    processPayment(payload, false);
+  }
+
+  private void processPayment(Map<String, Object> payload, boolean approved) {
+    UUID solId = extractSolicitationId(payload);
+    if (solId == null) {
+      log.warn("PaymentEvent without valid solicitationId: {}", payload);
+      return; // ack & ignore
+    }
+
+    Optional<Solicitation> opt = repository.findById(solId);
+    if (opt.isEmpty()) {
+      log.warn("Solicitation not found for payment event: {}", solId);
+      return; // ack & ignore
+    }
+
+    Solicitation s = opt.get();
+    if (s.getStatus() != Status.PENDING) {
+      log.info("Ignoring payment event for {} because status is {}", s.getId(), s.getStatus());
+      return; // idempotência
+    }
+
+    OffsetDateTime now = OffsetDateTime.now();
+    if (approved) {
+      s.setStatus(Status.APPROVED);
+      s.addHistory(Status.APPROVED, now);
+      s.setFinishedAt(now);
+      repository.save(s);
+      try {
+        eventPublisher.publishSolicitationApproved(
+            s.getId().toString(), s.getCustomerId().toString(), "PAYMENT_APPROVED");
+      } catch (Exception e) {
+        log.warn(
+            "Failed to publish SolicitationApprovedEvent for {}: {}", s.getId(), e.getMessage(), e);
+      }
+    } else {
+      s.setStatus(Status.REJECTED);
+      s.addHistory(Status.REJECTED, now);
+      s.setFinishedAt(now);
+      repository.save(s);
+      try {
+        eventPublisher.publishSolicitationRejected(
+            s.getId().toString(), s.getCustomerId().toString(), "PAYMENT_REJECTED");
+      } catch (Exception e) {
+        log.warn(
+            "Failed to publish SolicitationRejectedEvent for {}: {}", s.getId(), e.getMessage(), e);
+      }
+    }
+  }
+
+  private UUID extractSolicitationId(Map<String, Object> payload) {
+    Object idObj = payload.get("solicitationId");
+    if (!(idObj instanceof String s) || s.isBlank() || "null".equalsIgnoreCase(s)) {
+      return null;
+    }
+    try {
+      return UUID.fromString(s);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/br/com/danieldomingues/itau/policy/messaging/PolicyEventPublisher.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/messaging/PolicyEventPublisher.java
@@ -1,0 +1,47 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import br.com.danieldomingues.itau.policy.config.PolicyEventsConfig;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PolicyEventPublisher {
+
+  private final RabbitTemplate rabbitTemplate;
+
+  public PolicyEventPublisher(RabbitTemplate rabbitTemplate) {
+    this.rabbitTemplate = rabbitTemplate;
+    // Garantir uso do Jackson2JsonMessageConverter se registrado no contexto
+    // (Spring Boot autoconfig faz isso quando o bean existe)
+  }
+
+  public void publishSolicitationValidated(
+      String solicitationId, String customerId, String classification) {
+    Objects.requireNonNull(solicitationId, "solicitationId is required");
+    Map<String, Object> payload =
+        Map.of(
+            "type", "SolicitationValidatedEvent",
+            "solicitationId", solicitationId,
+            "customerId", customerId,
+            "classification", classification,
+            "occurredAt", OffsetDateTime.now().toString());
+    rabbitTemplate.convertAndSend(
+        PolicyEventsConfig.EXCHANGE_POLICY_LIFECYCLE, PolicyEventsConfig.RK_VALIDATED, payload);
+  }
+
+  public void publishSolicitationRejected(String solicitationId, String customerId, String reason) {
+    Objects.requireNonNull(solicitationId, "solicitationId is required");
+    Map<String, Object> payload =
+        Map.of(
+            "type", "SolicitationRejectedEvent",
+            "solicitationId", solicitationId,
+            "customerId", customerId,
+            "reason", reason,
+            "occurredAt", OffsetDateTime.now().toString());
+    rabbitTemplate.convertAndSend(
+        PolicyEventsConfig.EXCHANGE_POLICY_LIFECYCLE, PolicyEventsConfig.RK_REJECTED, payload);
+  }
+}

--- a/src/main/java/br/com/danieldomingues/itau/policy/messaging/SubscriptionEventListener.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/messaging/SubscriptionEventListener.java
@@ -1,0 +1,94 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionEventListener {
+
+  private final SolicitationRepository repository;
+  private final PolicyEventPublisher eventPublisher;
+
+  @Transactional
+  @RabbitListener(queues = "policy.subscription.active.q")
+  public void onSubscriptionActive(Map<String, Object> payload) {
+    processSubscription(payload, true);
+  }
+
+  @Transactional
+  @RabbitListener(queues = "policy.subscription.rejected.q")
+  public void onSubscriptionRejected(Map<String, Object> payload) {
+    processSubscription(payload, false);
+  }
+
+  private void processSubscription(Map<String, Object> payload, boolean active) {
+    UUID solId = extractSolicitationId(payload);
+    if (solId == null) {
+      log.warn("SubscriptionEvent without valid solicitationId: {}", payload);
+      return; // ack & ignore
+    }
+
+    Optional<Solicitation> opt = repository.findById(solId);
+    if (opt.isEmpty()) {
+      log.warn("Solicitation not found for subscription event: {}", solId);
+      return; // ack & ignore
+    }
+
+    Solicitation s = opt.get();
+    if (s.getStatus() != Status.PENDING) {
+      log.info("Ignoring subscription event for {} because status is {}", s.getId(), s.getStatus());
+      return; // idempotência
+    }
+
+    OffsetDateTime now = OffsetDateTime.now();
+    if (active) {
+      s.setStatus(Status.APPROVED);
+      s.addHistory(Status.APPROVED, now);
+      s.setFinishedAt(now);
+      repository.save(s);
+      try {
+        eventPublisher.publishSolicitationApproved(
+            s.getId().toString(), s.getCustomerId().toString(), "SUBSCRIPTION_ACTIVE");
+      } catch (Exception e) {
+        log.warn(
+            "Failed to publish SolicitationApprovedEvent for {}: {}", s.getId(), e.getMessage(), e);
+      }
+    } else {
+      s.setStatus(Status.REJECTED);
+      s.addHistory(Status.REJECTED, now);
+      s.setFinishedAt(now);
+      repository.save(s);
+      try {
+        eventPublisher.publishSolicitationRejected(
+            s.getId().toString(), s.getCustomerId().toString(), "SUBSCRIPTION_REJECTED");
+      } catch (Exception e) {
+        log.warn(
+            "Failed to publish SolicitationRejectedEvent for {}: {}", s.getId(), e.getMessage(), e);
+      }
+    }
+  }
+
+  private UUID extractSolicitationId(Map<String, Object> payload) {
+    Object idObj = payload.get("solicitationId");
+    if (!(idObj instanceof String s) || s.isBlank() || "null".equalsIgnoreCase(s)) {
+      return null;
+    }
+    try {
+      return UUID.fromString(s);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/br/com/danieldomingues/itau/policy/service/FraudValidationService.java
+++ b/src/main/java/br/com/danieldomingues/itau/policy/service/FraudValidationService.java
@@ -5,6 +5,7 @@ import br.com.danieldomingues.itau.policy.domain.Status;
 import br.com.danieldomingues.itau.policy.integration.fraud.FraudClient;
 import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckRequest;
 import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckResponse;
+import br.com.danieldomingues.itau.policy.messaging.PolicyEventPublisher;
 import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
 import java.time.OffsetDateTime;
 import java.util.Locale;
@@ -14,16 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Orquestra a validação de fraudes e realiza a transição de estado:
- * RECEIVED -> VALIDATED/REJECTED, registrando histórico.
- *
- * Regras (Mock/WireMock):
- *  - REGULAR/PREFERENTIAL  -> VALIDATED
- *  - HIGH_RISK/NO_INFO     -> REJECTED  (finaliza solicitação)
- *
- * Idempotente: se a solicitação já estiver VALIDATED/REJECTED, não altera.
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -31,6 +22,7 @@ public class FraudValidationService {
 
   private final SolicitationRepository repository;
   private final FraudClient fraudClient;
+  private final PolicyEventPublisher eventPublisher; // <-- novo
 
   @Transactional
   public Solicitation validate(UUID solicitationId) {
@@ -40,7 +32,7 @@ public class FraudValidationService {
             .orElseThrow(
                 () -> new IllegalArgumentException("Solicitation not found: " + solicitationId));
 
-    // Idempotência: já processada
+    // Idempotência
     if (s.getStatus() == Status.VALIDATED || s.getStatus() == Status.REJECTED) {
       log.info("Solicitation {} already processed with status {}", s.getId(), s.getStatus());
       return s;
@@ -68,17 +60,47 @@ public class FraudValidationService {
       case "REGULAR", "PREFERENTIAL" -> {
         s.setStatus(Status.VALIDATED);
         s.addHistory(Status.VALIDATED, now);
+        try {
+          eventPublisher.publishSolicitationValidated(
+              s.getId().toString(), s.getCustomerId().toString(), classification);
+        } catch (Exception e) {
+          log.warn(
+              "Failed to publish SolicitationValidatedEvent for {}: {}",
+              s.getId(),
+              e.getMessage(),
+              e);
+        }
       }
       case "HIGH_RISK", "NO_INFO" -> {
         s.setStatus(Status.REJECTED);
         s.addHistory(Status.REJECTED, now);
         s.setFinishedAt(now);
+        try {
+          eventPublisher.publishSolicitationRejected(
+              s.getId().toString(), s.getCustomerId().toString(), classification);
+        } catch (Exception e) {
+          log.warn(
+              "Failed to publish SolicitationRejectedEvent for {}: {}",
+              s.getId(),
+              e.getMessage(),
+              e);
+        }
       }
       default -> {
         log.warn("Unknown fraud classification '{}', defaulting to REJECTED", classification);
         s.setStatus(Status.REJECTED);
         s.addHistory(Status.REJECTED, now);
         s.setFinishedAt(now);
+        try {
+          eventPublisher.publishSolicitationRejected(
+              s.getId().toString(), s.getCustomerId().toString(), classification);
+        } catch (Exception e) {
+          log.warn(
+              "Failed to publish SolicitationRejectedEvent (default) for {}: {}",
+              s.getId(),
+              e.getMessage(),
+              e);
+        }
       }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     password: itau
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate.format_sql: true
       hibernate.jdbc.time_zone: UTC

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,11 @@ spring:
     port: 5672
     username: guest
     password: guest
+    listener:
+      simple:
+        auto-startup: false
+      direct:
+        auto-startup: false
 
 fraud:
   api:

--- a/src/test/java/br/com/danieldomingues/itau/policy/messaging/PaymentEventListenerTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/messaging/PaymentEventListenerTest.java
@@ -1,0 +1,99 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import br.com.danieldomingues.itau.policy.domain.Category;
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.math.BigDecimal;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PaymentEventListenerTest {
+
+  private SolicitationRepository repository;
+  private PolicyEventPublisher publisher;
+  private PaymentEventListener listener;
+  private SolicitationFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(SolicitationRepository.class);
+    publisher = mock(PolicyEventPublisher.class);
+    listener = new PaymentEventListener(repository, publisher);
+    factory = new SolicitationFactory();
+  }
+
+  private Solicitation pendingSolicitation() {
+    Solicitation s =
+        factory.newSolicitation(
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            Category.AUTO,
+            "MOBILE",
+            "CREDIT_CARD",
+            BigDecimal.valueOf(100.0),
+            BigDecimal.valueOf(10000.0),
+            Collections.emptyMap(),
+            Collections.emptyList());
+    s.setId(UUID.randomUUID());
+    s.setStatus(Status.PENDING);
+    return s;
+  }
+
+  @Test
+  void onPaymentApproved_shouldSetApproved_andPublishApproved() {
+    Solicitation s = pendingSolicitation();
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    Map<String, Object> payload = Map.of("solicitationId", s.getId().toString());
+    listener.onPaymentApproved(payload);
+
+    verify(repository, times(1)).save(s);
+    // terminou em estado terminal
+    assert s.getStatus() == Status.APPROVED;
+    verify(publisher, times(1))
+        .publishSolicitationApproved(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), anyString());
+    verify(publisher, never()).publishSolicitationRejected(any(), any(), any());
+  }
+
+  @Test
+  void onPaymentRejected_shouldSetRejected_andPublishRejected() {
+    Solicitation s = pendingSolicitation();
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    Map<String, Object> payload = Map.of("solicitationId", s.getId().toString());
+    listener.onPaymentRejected(payload);
+
+    verify(repository, times(1)).save(s);
+    assert s.getStatus() == Status.REJECTED;
+    verify(publisher, times(1))
+        .publishSolicitationRejected(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), anyString());
+    verify(publisher, never()).publishSolicitationApproved(any(), any(), any());
+  }
+
+  @Test
+  void shouldIgnoreWhenSolicitationNotFound() {
+    UUID missing = UUID.randomUUID();
+    when(repository.findById(missing)).thenReturn(Optional.empty());
+    listener.onPaymentApproved(Map.of("solicitationId", missing.toString()));
+    verify(repository, never()).save(any());
+    verifyNoInteractions(publisher);
+  }
+
+  @Test
+  void shouldIgnoreWhenNotPending() {
+    Solicitation s = pendingSolicitation();
+    s.setStatus(Status.VALIDATED); // não é PENDING
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+    listener.onPaymentApproved(Map.of("solicitationId", s.getId().toString()));
+    verify(repository, never()).save(any());
+    verifyNoInteractions(publisher);
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/messaging/PolicyEventPublisherTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/messaging/PolicyEventPublisherTest.java
@@ -1,0 +1,33 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+class PolicyEventPublisherTest {
+
+  @Test
+  void shouldPublishWithCorrectRoutingKeys() {
+    RabbitTemplate rabbit = mock(RabbitTemplate.class);
+    TopicExchange exchange = mock(TopicExchange.class);
+    when(exchange.getName()).thenReturn("policy.lifecycle");
+
+    // construtor real: (RabbitTemplate, TopicExchange)
+    PolicyEventPublisher publisher = new PolicyEventPublisher(rabbit, exchange);
+
+    publisher.publishSolicitationValidated("s1", "c1", "REGULAR");
+    publisher.publishSolicitationRejected("s2", "c2", "NO_INFO");
+    publisher.publishSolicitationApproved("s3", "c3", "PAYMENT_APPROVED");
+
+    // usar anyMap() evita a ambiguidade de overloads do convertAndSend
+    verify(rabbit, times(1))
+        .convertAndSend(eq("policy.lifecycle"), eq("solicitation.validated"), anyMap());
+    verify(rabbit, times(1))
+        .convertAndSend(eq("policy.lifecycle"), eq("solicitation.rejected"), anyMap());
+    verify(rabbit, times(1))
+        .convertAndSend(eq("policy.lifecycle"), eq("solicitation.approved"), anyMap());
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/messaging/SubscriptionEventListenerTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/messaging/SubscriptionEventListenerTest.java
@@ -1,0 +1,83 @@
+package br.com.danieldomingues.itau.policy.messaging;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import br.com.danieldomingues.itau.policy.domain.Category;
+import br.com.danieldomingues.itau.policy.domain.Solicitation;
+import br.com.danieldomingues.itau.policy.domain.Status;
+import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
+import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
+import java.math.BigDecimal;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionEventListenerTest {
+
+  private SolicitationRepository repository;
+  private PolicyEventPublisher publisher;
+  private SubscriptionEventListener listener;
+  private SolicitationFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(SolicitationRepository.class);
+    publisher = mock(PolicyEventPublisher.class);
+    listener = new SubscriptionEventListener(repository, publisher);
+    factory = new SolicitationFactory();
+  }
+
+  private Solicitation pendingSolicitation() {
+    Solicitation s =
+        factory.newSolicitation(
+            UUID.randomUUID(),
+            UUID.randomUUID().toString(),
+            Category.LIFE,
+            "WEB",
+            "PIX",
+            BigDecimal.valueOf(50.0),
+            BigDecimal.valueOf(5000.0),
+            Collections.emptyMap(),
+            Collections.emptyList());
+    s.setId(UUID.randomUUID());
+    s.setStatus(Status.PENDING);
+    return s;
+  }
+
+  @Test
+  void onSubscriptionActive_shouldApprove_andPublishApproved() {
+    Solicitation s = pendingSolicitation();
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    listener.onSubscriptionActive(Map.of("solicitationId", s.getId().toString()));
+
+    verify(repository, times(1)).save(s);
+    assert s.getStatus() == Status.APPROVED;
+    verify(publisher, times(1))
+        .publishSolicitationApproved(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), anyString());
+    verify(publisher, never()).publishSolicitationRejected(any(), any(), any());
+  }
+
+  @Test
+  void onSubscriptionRejected_shouldReject_andPublishRejected() {
+    Solicitation s = pendingSolicitation();
+    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
+
+    listener.onSubscriptionRejected(Map.of("solicitationId", s.getId().toString()));
+
+    verify(repository, times(1)).save(s);
+    assert s.getStatus() == Status.REJECTED;
+    verify(publisher, times(1))
+        .publishSolicitationRejected(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), anyString());
+    verify(publisher, never()).publishSolicitationApproved(any(), any(), any());
+  }
+
+  @Test
+  void shouldIgnoreWhenMissingId() {
+    listener.onSubscriptionActive(Map.of()); // sem solicitationId
+    verifyNoInteractions(repository, publisher);
+  }
+}

--- a/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceAdditionalTest.java
+++ b/src/test/java/br/com/danieldomingues/itau/policy/service/FraudValidationServiceAdditionalTest.java
@@ -3,6 +3,7 @@ package br.com.danieldomingues.itau.policy.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import br.com.danieldomingues.itau.policy.domain.Category;
@@ -12,11 +13,10 @@ import br.com.danieldomingues.itau.policy.factory.SolicitationFactory;
 import br.com.danieldomingues.itau.policy.integration.fraud.FraudClient;
 import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckRequest;
 import br.com.danieldomingues.itau.policy.integration.fraud.dto.FraudCheckResponse;
+import br.com.danieldomingues.itau.policy.messaging.PolicyEventPublisher;
 import br.com.danieldomingues.itau.policy.repo.SolicitationRepository;
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,16 +26,87 @@ class FraudValidationServiceAdditionalTest {
 
   private SolicitationRepository repository;
   private FraudClient fraudClient;
+  private PolicyEventPublisher eventPublisher; // novo
   private FraudValidationService service;
-  private SolicitationFactory factory;
+
+  private final SolicitationFactory factory = new SolicitationFactory();
 
   @BeforeEach
   void setup() {
     repository = mock(SolicitationRepository.class);
     fraudClient = mock(FraudClient.class);
-    service = new FraudValidationService(repository, fraudClient);
-    factory = new SolicitationFactory();
+    eventPublisher = mock(PolicyEventPublisher.class); // novo
+    service = new FraudValidationService(repository, fraudClient, eventPublisher); // 3 args
   }
+
+  @Test
+  void shouldValidateWhenRegular() {
+    Solicitation s = newSolicitation(Category.AUTO, 10000.00);
+    when(repository.findById(s.getId())).thenReturn(java.util.Optional.of(s));
+    ArgumentCaptor<FraudCheckRequest> reqCap = ArgumentCaptor.forClass(FraudCheckRequest.class);
+    when(fraudClient.check(reqCap.capture()))
+        .thenReturn(FraudCheckResponse.builder().classification("REGULAR").build());
+    when(repository.save(any(Solicitation.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Solicitation result = service.validate(s.getId());
+
+    assertThat(result.getStatus()).isEqualTo(Status.VALIDATED);
+    FraudCheckRequest sent = reqCap.getValue();
+    assertThat(sent).isNotNull();
+    assertThat(sent.getCustomerId()).isEqualTo(s.getCustomerId());
+    assertThat(sent.getProductId()).isEqualTo(s.getProductId());
+
+    verify(eventPublisher, times(1))
+        .publishSolicitationValidated(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), any());
+    verify(eventPublisher, never()).publishSolicitationRejected(any(), any(), any());
+  }
+
+  @Test
+  void shouldRejectWhenHighRisk() {
+    Solicitation s = newSolicitation(Category.LIFE, 50000.00);
+    when(repository.findById(s.getId())).thenReturn(java.util.Optional.of(s));
+    when(fraudClient.check(any()))
+        .thenReturn(FraudCheckResponse.builder().classification("HIGH_RISK").build());
+    when(repository.save(any(Solicitation.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Solicitation result = service.validate(s.getId());
+
+    assertThat(result.getStatus()).isEqualTo(Status.REJECTED);
+    verify(eventPublisher, times(1))
+        .publishSolicitationRejected(
+            eq(s.getId().toString()), eq(s.getCustomerId().toString()), any());
+    verify(eventPublisher, never()).publishSolicitationValidated(any(), any(), any());
+  }
+
+  @Test
+  void shouldBeIdempotent() {
+    Solicitation s = newSolicitation(Category.OTHER, 1000.00);
+    s.setStatus(Status.VALIDATED);
+    when(repository.findById(s.getId())).thenReturn(java.util.Optional.of(s));
+
+    Solicitation result = service.validate(s.getId());
+
+    assertThat(result.getStatus()).isEqualTo(Status.VALIDATED);
+    verifyNoInteractions(eventPublisher);
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void shouldThrowWhenNotReceived() {
+    Solicitation s = newSolicitation(Category.RESIDENTIAL, 2000.00);
+    s.setStatus(Status.PENDING); // estado inválido para validar
+    when(repository.findById(s.getId())).thenReturn(java.util.Optional.of(s));
+
+    assertThatThrownBy(() -> service.validate(s.getId()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Invalid state to validate");
+
+    verifyNoInteractions(eventPublisher);
+    verify(repository, never()).save(any());
+  }
+
+  // ---- Helper
 
   private Solicitation newSolicitation(Category category, double insuredAmount) {
     Solicitation s =
@@ -49,91 +120,9 @@ class FraudValidationServiceAdditionalTest {
             BigDecimal.valueOf(insuredAmount),
             Collections.emptyMap(),
             Collections.emptyList());
-    // simulamos o estado inicial esperado pelo domínio (@PrePersist faria isso no runtime)
+    // Garante identidade/estado inicial esperado pelos testes:
     s.setId(UUID.randomUUID());
     s.setStatus(Status.RECEIVED);
-    s.addHistory(Status.RECEIVED, OffsetDateTime.now());
     return s;
-  }
-
-  @Test
-  void notFound_shouldThrowIllegalArgumentException() {
-    UUID id = UUID.randomUUID();
-    when(repository.findById(id)).thenReturn(Optional.empty());
-
-    assertThatThrownBy(() -> service.validate(id))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Solicitation not found");
-
-    verify(repository, never()).save(any());
-    verify(fraudClient, never()).check(any());
-  }
-
-  @Test
-  void alreadyRejected_shouldBeIdempotent_andNotCallFraudOrSave() {
-    Solicitation s = newSolicitation(Category.AUTO, 100_000);
-    s.setStatus(Status.REJECTED);
-    s.setFinishedAt(OffsetDateTime.now());
-
-    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
-
-    Solicitation out = service.validate(s.getId());
-
-    // não chama cliente nem persiste
-    verify(fraudClient, never()).check(any());
-    verify(repository, never()).save(any());
-
-    assertThat(out.getStatus()).isEqualTo(Status.REJECTED);
-    assertThat(out.getFinishedAt()).isNotNull();
-  }
-
-  @Test
-  void highRisk_shouldReject_setFinishedAt_andAppendHistory() {
-    Solicitation s = newSolicitation(Category.RESIDENTIAL, 200_000);
-
-    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
-    when(fraudClient.check(any(FraudCheckRequest.class)))
-        .thenReturn(FraudCheckResponse.builder().classification("HIGH_RISK").build());
-
-    Solicitation saved = newSolicitation(Category.RESIDENTIAL, 200_000);
-    saved.setId(s.getId()); // simula retorno do save com o mesmo id
-    saved.setStatus(Status.REJECTED);
-    saved.setFinishedAt(OffsetDateTime.now());
-    // histórico já continha RECEIVED; adiciona REJECTED
-    saved.addHistory(Status.REJECTED, saved.getFinishedAt());
-
-    when(repository.save(any(Solicitation.class))).thenReturn(saved);
-
-    Solicitation result = service.validate(s.getId());
-
-    assertThat(result.getStatus()).isEqualTo(Status.REJECTED);
-    assertThat(result.getFinishedAt()).isNotNull();
-    // deve ter pelo menos RECEIVED + REJECTED
-    assertThat(result.getHistory().size()).isGreaterThanOrEqualTo(2);
-    assertThat(result.getHistory().get(0).getStatus()).isEqualTo(Status.RECEIVED);
-    assertThat(result.getHistory().get(result.getHistory().size() - 1).getStatus())
-        .isEqualTo(Status.REJECTED);
-  }
-
-  @Test
-  void shouldBuildFraudCheckRequest_withCustomerAndProduct_fromEntity() {
-    Solicitation s = newSolicitation(Category.LIFE, 300_000);
-
-    when(repository.findById(s.getId())).thenReturn(Optional.of(s));
-
-    // capturar o request enviado ao client
-    ArgumentCaptor<FraudCheckRequest> reqCap = ArgumentCaptor.forClass(FraudCheckRequest.class);
-    when(fraudClient.check(reqCap.capture()))
-        .thenReturn(FraudCheckResponse.builder().classification("REGULAR").build());
-
-    // salvar devolve a própria entidade alterada
-    when(repository.save(any(Solicitation.class))).thenAnswer(inv -> inv.getArgument(0));
-
-    service.validate(s.getId());
-
-    FraudCheckRequest sent = reqCap.getValue();
-    assertThat(sent).isNotNull();
-    assertThat(sent.getCustomerId()).isEqualTo(s.getCustomerId());
-    assertThat(sent.getProductId()).isEqualTo(s.getProductId());
   }
 }


### PR DESCRIPTION
…uração

- Adicionado PolicyEventsConfig com exchanges, filas e bindings base
- Criado PolicyEventPublisher para emissão de eventos VALIDATED/REJECTED
- Integrado FraudValidationService com publisher de eventos
- Ajustado application.yml para ddl-auto=create em dev/test
- Atualizado pom.xml com configuração JaCoCo e -parameters
- Corrigidos testes FraudValidationServiceAdditionalTest e FraudValidationServiceRulesTest para usar PolicyEventPublisher mock